### PR TITLE
Add quote escaping of error message before passing to zabbix json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # zabbix-speedtest.net change log
 
+## v2.0.4 - 2021-04-12
+* Escape quotes in error message passed back to zabbix. Handles odd issue with recent (now fixed) bug in speedtest-cli [Handle case where ignoreids is empty or contains empty ids](https://github.com/sivel/speedtest-cli/commit/cadc68b5aef20f28648072cf07a8f155639b81dd)
+
 ## v2.0.3 - 2020-11-11
 * Rename All-In-One report to "Speedtest Summary"
  * Update graph colors and summary graph to be cleaner

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Zabbix template for monitoring ISP speeds using speedtest.net.
 
 To avoid timeouts when executing the speed test this template uses a combination of a trigger item and a trap item to asynchronously execute the speed test.
 
-Latest version is v2.0.3 (2020-11-11). [Change Log](CHANGELOG.md)
+Latest version is v2.0.4 (2021-04-12). [Change Log](CHANGELOG.md)
 
 ## Dependencies
 * [speedtest-cli](https://github.com/sivel/speedtest-cli)

--- a/isp-speedtest-sender.sh
+++ b/isp-speedtest-sender.sh
@@ -59,7 +59,8 @@ fi
 
 retVal=$?
 if [ $retVal -ne 0 ]; then
-  zabbix_send "{\"success\": 0, \"message\": \"speedtest failure code [$retVal], output: [${SPEEDTEST_OUTPUT}]\"}"
+  SPEEDTEST_OUTPUT=$(echo $SPEEDTEST_OUTPUT | sed 's/\"//g')
+  zabbix_send "{\"success\": 0, \"message\": \"speedtest failure code [$retVal], output: [${SPEEDTEST_OUTPUT}]\", \"latency\": 0, \"download\": 0, \"upload\": 0, \"host\": null}"
   exit 1
 fi
 

--- a/zabbix_isp_speedtest_template.xml
+++ b/zabbix_isp_speedtest_template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>5.0</version>
-    <date>2020-11-12T01:54:43Z</date>
+    <date>2021-04-12T23:12:46Z</date>
     <groups>
         <group>
             <name>Templates/Network devices</name>
@@ -16,7 +16,7 @@
 Note: speedtest-cli does not guarantee accuracy or consistency with the web based speedtest.net but it is useful for general trending and notification when large changes to internet access speed happen. See the &quot;Inconsistency&quot; notes on the speedtest-cli readme: https://github.com/sivel/speedtest-cli&#13;
 &#13;
 &#13;
-v2.0.3 - 2020-11-11&#13;
+v2.0.4 - 2021-04-12&#13;
 &#13;
 Maintainer: Rob McCready &lt;rmccready@gmail.com&gt;&#13;
 https://github.com/robmccready/zabbix-isp-speedtest</description>


### PR DESCRIPTION
Fix escaping of error message that comes back from odd speedtest-cli issue. Bad quoting caused sub items to not parse so the failure trigger was not activated.